### PR TITLE
Add get handler and client state validator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ actix-cors = "0.2"
 cadence = "0.19.1"
 config = "0.9.3"
 docopt = "1.1"
+regex = "1.3.9"
 diesel = { version = "1.4.3", features = ["mysql", "r2d2"] }
 diesel_logger = "0.1.0"
 diesel_migrations = { version = "1.4.0", features = ["mysql"] }

--- a/src/server/extractors.rs
+++ b/src/server/extractors.rs
@@ -1,0 +1,34 @@
+use regex::Regex;
+use actix_web::{
+    Error, FromRequest,
+};
+use futures::future::{ok, err, Ready};
+use actix_web::error::ErrorBadRequest;
+
+pub struct  ClientState {
+   value: String,
+}
+
+impl FromRequest for ClientState {
+    type Config = ();
+    type Error = Error;
+    type Future = Ready<Result<Self, Self::Error>>;
+
+    fn from_request(req: &::actix_web::HttpRequest,
+                    payload: &mut actix_web::dev::Payload,) -> Self::Future {
+
+        let client_state: &str = req.headers().get("X-Client-State").unwrap()
+                                        .to_str().unwrap();
+        lazy_static! {
+        let re = Regex::new(r"\^[a-zA-Z0-9\._\-]{1,32}$").unwrap();
+        }
+
+        if re.is_match(client_state) {
+            ok(ClientState{ value: client_state.to_string().into() })
+
+        } else {
+            err(ErrorBadRequest("Invalid Client State."))
+
+        }
+    }
+}

--- a/src/server/extractors.rs
+++ b/src/server/extractors.rs
@@ -1,34 +1,111 @@
-use regex::Regex;
-use actix_web::{
-    Error, FromRequest,
-};
-use futures::future::{ok, err, Ready};
 use actix_web::error::ErrorBadRequest;
-
-pub struct  ClientState {
-   value: String,
+use actix_web::{Error, FromRequest, Responder};
+use futures::future::{err, ok, Ready};
+use lazy_static::lazy_static;
+use regex::Regex;
+use serde::Deserialize;
+lazy_static! {
+    static ref RE_EXP: Regex = Regex::new(r"^[a-zA-Z0-9\._\-]{1,32}$").unwrap();
+}
+#[derive(Debug, Deserialize)]
+pub struct ClientState {
+    value: String,
 }
 
 impl FromRequest for ClientState {
     type Config = ();
     type Error = Error;
     type Future = Ready<Result<Self, Self::Error>>;
+    // type Result = Future<Item = Self, Error = Error>;
 
-    fn from_request(req: &::actix_web::HttpRequest,
-                    payload: &mut actix_web::dev::Payload,) -> Self::Future {
+    fn from_request(
+        req: &::actix_web::HttpRequest,
+        _payload: &mut actix_web::dev::Payload,
+    ) -> Self::Future {
+        let client_state: &str = req
+            .headers()
+            .get("X-Client-State")
+            .unwrap()
+            .to_str()
+            .unwrap();
 
-        let client_state: &str = req.headers().get("X-Client-State").unwrap()
-                                        .to_str().unwrap();
-        lazy_static! {
-        let re = Regex::new(r"\^[a-zA-Z0-9\._\-]{1,32}$").unwrap();
-        }
-
-        if re.is_match(client_state) {
-            ok(ClientState{ value: client_state.to_string().into() })
-
+        if RE_EXP.is_match(client_state) {
+            ok(ClientState {
+                value: client_state.to_string(),
+            })
         } else {
             err(ErrorBadRequest("Invalid Client State."))
-
         }
+    }
+}
+
+async fn extract_client_state(state: ClientState) -> impl Responder {
+    state.value
+}
+
+//Negative tests
+#[actix_rt::test]
+async fn test_extractor1() {
+    use super::*;
+    use actix_web::test;
+
+    let mut app = test::init_service(
+        App::new().service(web::resource("/test/extractor").route(web::to(extract_client_state))),
+    )
+    .await;
+    let req = test::TestRequest::with_header("X-Client-State", "12345678~90ab-567890ab")
+        .uri("/test/extractor")
+        .to_request();
+    let res = test::call_service(&mut app, req).await;
+
+    let var = test::read_body(res).await;
+    let var2 = std::str::from_utf8(&var).unwrap();
+    if !RE_EXP.is_match(var2) {
+        assert_eq!(var2, "Invalid Client State.");
+    }
+}
+
+#[actix_rt::test]
+async fn test_extractor2() {
+    use super::*;
+    use actix_web::test;
+
+    let mut app = test::init_service(
+        App::new().service(web::resource("/test/extractor").route(web::to(extract_client_state))),
+    )
+    .await;
+    let req = test::TestRequest::with_header(
+        "X-Client-State",
+        "12345678-1234-1234-1234-1234567890abcdef-1234",
+    )
+    .uri("/test/extractor")
+    .to_request();
+    let res = test::call_service(&mut app, req).await;
+
+    let var = test::read_body(res).await;
+    let var2 = std::str::from_utf8(&var).unwrap();
+    if !RE_EXP.is_match(var2) {
+        assert_eq!(var2, "Invalid Client State.");
+    }
+}
+
+#[actix_rt::test]
+async fn test_extractor3() {
+    use super::*;
+    use actix_web::test;
+
+    let mut app = test::init_service(
+        App::new().service(web::resource("/test/extractor").route(web::to(extract_client_state))),
+    )
+    .await;
+    let req = test::TestRequest::with_header("X-Client-State", "12345678|1234-@#$%90abcdef")
+        .uri("/test/extractor")
+        .to_request();
+    let res = test::call_service(&mut app, req).await;
+
+    let var = test::read_body(res).await;
+    let var2 = std::str::from_utf8(&var).unwrap();
+    if !RE_EXP.is_match(var2) {
+        assert_eq!(var2, "Invalid Client State.");
     }
 }

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -10,15 +10,13 @@ async fn test_index() {
     use super::*;
     use actix_web::test;
     let mut app = test::init_service(
-                        App::new().service(
-                        web::resource("/1.0/sync/1.5")
-                        .route(web::post().to(get_handler)))
-                    ).await;
+        App::new().service(web::resource("/1.0/sync/1.5").route(web::get().to(get_handler))),
+    )
+    .await;
 
-    let req = test::TestRequest::post()
-                                    .uri("/1.0/sync/1.5")
-                                    .to_request();
+    let req = test::TestRequest::get().uri("/1.0/sync/1.5").to_request();
     let res = test::call_service(&mut app, req).await;
+    println!("{:?}", res);
 
     assert_eq!(res.status(), 200, "/1.0/sync/1.5 should return 200");
 }

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -1,0 +1,24 @@
+use actix_web::{HttpRequest, HttpResponse, Responder};
+
+pub async fn get_handler(_req: HttpRequest) -> impl Responder {
+    HttpResponse::Ok()
+        .content_type("application/json")
+        .body("{}")
+}
+#[actix_rt::test]
+async fn test_index() {
+    use super::*;
+    use actix_web::test;
+    let mut app = test::init_service(
+                        App::new().service(
+                        web::resource("/1.0/sync/1.5")
+                        .route(web::post().to(get_handler)))
+                    ).await;
+
+    let req = test::TestRequest::post()
+                                    .uri("/1.0/sync/1.5")
+                                    .to_request();
+    let res = test::call_service(&mut app, req).await;
+
+    assert_eq!(res.status(), 200, "/1.0/sync/1.5 should return 200");
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,11 +1,15 @@
 //! Main application server
 
+mod extractors;
+mod handlers;
 use actix_cors::Cors;
 use actix_web::{
     dev, http::StatusCode, middleware::errhandlers::ErrorHandlers, web, App, HttpRequest,
     HttpResponse, HttpServer,
 };
 use cadence::StatsdClient;
+
+use handlers::get_handler;
 
 use crate::error::ApiError;
 use crate::metrics;
@@ -46,6 +50,7 @@ impl Server {
                             .body("{}")
                     },
                 )))
+                .service(web::resource("/1.0/sync/1.5").route(web::get().to(get_handler)))
                 .service(
                     web::resource("/__version__").route(web::get().to(|_: HttpRequest| {
                         // return the contents of the version.json file created by circleci


### PR DESCRIPTION
This PR implement  a basic GET handler w/ a test in file `src/server/handlers.rs` . It also adds a ClientState validator implemented as actix-web extractors in file `src/server/extractors.rs`. It solves issue#10. 

Describe these changes.
I have added files `handlers.rs` in `src/server` where a get handler is implemented which returns a 200  response and `extractors.rs` in `src/server` where a ClientState validator is implemented as actix-web extractors which extracts the clientstate from request header and compares it with a regex and returns a instance of ClientState if clientstate matches the regex else it yields an error.

## Testing

How should reviewers test?
No extra test needed.

## Issue(s)
https://github.com/mozilla-services/tokenserver-rs/issues/10

Closes #Issue.
